### PR TITLE
modif pour charger que les rides correspondantes à l'onglet d'ouvert

### DIFF
--- a/Sources/RideHistory/List/RideHistoryController.swift
+++ b/Sources/RideHistory/List/RideHistoryController.swift
@@ -67,6 +67,9 @@ class RideHistoryController: UIViewController {
         model.applySnapshot(in: datasource) {
             
         }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
         rideDelegate.loadRides(for: rideState) { [weak self] rides in
             self?.reloadRides(rides)
         }


### PR DESCRIPTION
si la méthode reloadRides(...) est laissée dans viewDidload, les rides du premier onglet sont automatiquement chargés quand on ouvre la page ridehistory sur un onglet défini (autre que le premier)